### PR TITLE
Feature: User can favorite a meal and view favorited meals

### DIFF
--- a/react-native-coursework/section-6-meals-app/Meals/App.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/App.tsx
@@ -7,6 +7,7 @@ import { DrawerContent, createDrawerNavigator } from "@react-navigation/drawer";
 import "react-native-gesture-handler";
 import { Ionicons } from '@expo/vector-icons'
 
+import FavoritesContextProvider from './store/context/FavoritesContext';
 import CategoriesScreen from './screens/CategoriesScreen';
 import MealsOverviewScreen from './screens/MealsOverviewScreen';
 import MealDetailScreen from './screens/MealDetailScreen';
@@ -69,37 +70,39 @@ export default function App() {
   return (
     <>
       <StatusBar style='light'/>
-      <NavigationContainer>
-        <RootStack.Navigator
-          screenOptions={{
-            headerStyle: {
-              backgroundColor: '#351401',
-            },
-            headerTintColor: 'white',
-            cardStyle: {
-              backgroundColor: 'black'
-            }
-          }}
-        >
-          <RootStack.Screen
-            name='Drawer'
-            component={DrawerNavigator}
-            options={{
-              title: 'Categories',
-              headerShown: false
+      <FavoritesContextProvider>
+        <NavigationContainer>
+          <RootStack.Navigator
+            screenOptions={{
+              headerStyle: {
+                backgroundColor: '#351401',
+              },
+              headerTintColor: 'white',
+              cardStyle: {
+                backgroundColor: 'black'
+              }
             }}
-          />
-           <RootStack.Screen
-            name='MealsOverview'
-            component={MealsOverviewScreen}
-          />
-          <RootStack.Screen 
-            name='MealDetail'
-            component={MealDetailScreen}
-          />
-          
-        </RootStack.Navigator>
-      </NavigationContainer>
+          >
+            <RootStack.Screen
+              name='Drawer'
+              component={DrawerNavigator}
+              options={{
+                title: 'Categories',
+                headerShown: false
+              }}
+            />
+             <RootStack.Screen
+              name='MealsOverview'
+              component={MealsOverviewScreen}
+            />
+            <RootStack.Screen
+              name='MealDetail'
+              component={MealDetailScreen}
+            />
+        
+          </RootStack.Navigator>
+        </NavigationContainer>
+      </FavoritesContextProvider>
     </>
   );
 }

--- a/react-native-coursework/section-6-meals-app/Meals/App.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/App.tsx
@@ -1,13 +1,13 @@
-import { StatusBar } from 'expo-status-bar';
 import { StyleSheet } from 'react-native';
-
+import { Provider } from 'react-redux';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
-import { DrawerContent, createDrawerNavigator } from "@react-navigation/drawer";
+import { createDrawerNavigator } from "@react-navigation/drawer";
 import "react-native-gesture-handler";
+import { StatusBar } from 'expo-status-bar';
 import { Ionicons } from '@expo/vector-icons'
 
-import FavoritesContextProvider from './store/context/FavoritesContext';
+import { store } from './store/redux/store';
 import CategoriesScreen from './screens/CategoriesScreen';
 import MealsOverviewScreen from './screens/MealsOverviewScreen';
 import MealDetailScreen from './screens/MealDetailScreen';
@@ -18,8 +18,6 @@ type RootStackParamList = {
   MealsOverview: {categoryId: string};
   MealDetail: {mealId: string}
 };
-
-
 
 const RootStack = createStackNavigator<RootStackParamList>();
 const Drawer = createDrawerNavigator();
@@ -63,14 +61,13 @@ function DrawerNavigator() {
       />
     </Drawer.Navigator>
   )
-
 }
 
 export default function App() {
   return (
     <>
       <StatusBar style='light'/>
-      <FavoritesContextProvider>
+      <Provider store={store}>
         <NavigationContainer>
           <RootStack.Navigator
             screenOptions={{
@@ -102,7 +99,7 @@ export default function App() {
         
           </RootStack.Navigator>
         </NavigationContainer>
-      </FavoritesContextProvider>
+      </Provider>
     </>
   );
 }

--- a/react-native-coursework/section-6-meals-app/Meals/components/IconButton.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/components/IconButton.tsx
@@ -5,7 +5,7 @@ import { GestureResponderEvent } from 'react-native'
 type IconName = React.ComponentProps<typeof Ionicons>['name'];
 
 interface IconButtonProps {
-  iconName: IconName;
+  iconName: IconName,
   onPress: (event: GestureResponderEvent) => void,
   color: string
 }

--- a/react-native-coursework/section-6-meals-app/Meals/components/MealDetail/List.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/components/MealDetail/List.tsx
@@ -29,5 +29,4 @@ const styles = StyleSheet.create({
     color: '#351401',
     textAlign: 'center'
   }
-
 })

--- a/react-native-coursework/section-6-meals-app/Meals/components/MealsList/MealsList.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/components/MealsList/MealsList.tsx
@@ -1,7 +1,6 @@
 import {View, FlatList, StyleSheet} from 'react-native';
 
 import MealItem from '../MealItem';
-
 import Meal from '../../models/meal';
 
 interface MealsListProps {
@@ -29,7 +28,7 @@ function MealsList({items}: MealsListProps) {
         renderItem={(itemData) => renderMealItem(itemData.item)}
       />
     </View>
-  )
+  );
 }
 
 export default MealsList;

--- a/react-native-coursework/section-6-meals-app/Meals/components/MealsList/MealsList.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/components/MealsList/MealsList.tsx
@@ -1,0 +1,42 @@
+import {View, FlatList, StyleSheet} from 'react-native';
+
+import MealItem from '../MealItem';
+
+import Meal from '../../models/meal';
+
+interface MealsListProps {
+  items: Meal[]
+}
+
+function MealsList({items}: MealsListProps) {
+
+  function renderMealItem(item: Meal) {
+    return <MealItem 
+            id={item.id}
+            title={item.title}
+            imageUrl={item.imageUrl}
+            duration={item.duration}
+            complexity={item.complexity}
+            affordability={item.affordability} 
+           />
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlatList 
+        data={items}
+        keyExtractor={(item) => item.id}
+        renderItem={(itemData) => renderMealItem(itemData.item)}
+      />
+    </View>
+  )
+}
+
+export default MealsList;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16
+  }
+})

--- a/react-native-coursework/section-6-meals-app/Meals/package-lock.json
+++ b/react-native-coursework/section-6-meals-app/Meals/package-lock.json
@@ -12,6 +12,7 @@
         "@react-navigation/native": "^6.1.6",
         "@react-navigation/native-stack": "^6.9.12",
         "@react-navigation/stack": "^6.3.16",
+        "@reduxjs/toolkit": "^1.9.3",
         "expo": "~48.0.10",
         "expo-status-bar": "~1.4.4",
         "react": "18.2.0",
@@ -19,7 +20,8 @@
         "react-native-gesture-handler": "~2.9.0",
         "react-native-reanimated": "~2.14.4",
         "react-native-safe-area-context": "4.5.0",
-        "react-native-screens": "~3.20.0"
+        "react-native-screens": "~3.20.0",
+        "react-redux": "^8.0.5"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -4773,6 +4775,29 @@
         "react-native-screens": ">= 3.0.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.3.tgz",
+      "integrity": "sha512-GU2TNBQVofL09VGmuSioNPQIu6Ml0YLf4EJhgj0AvBadRlCGzUWet8372LjvO4fqKZF2vH1xU0htAa7BrK9pZg==",
+      "dependencies": {
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -4826,6 +4851,15 @@
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
       "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -4855,14 +4889,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
       "version": "18.0.34",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.34.tgz",
       "integrity": "sha512-NO1UO8941541CJl1BeOXi8a9dNKFK09Gnru5ZJqkm4Q3/WoQJtHvmwt0VX0SB9YCEwe7TfSSxDuaNmx6H2BAIQ==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4872,13 +4904,17 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "dev": true
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/yargs": {
       "version": "15.0.15",
@@ -6285,8 +6321,7 @@
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/dag-map": {
       "version": "1.0.2",
@@ -7749,6 +7784,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -11350,6 +11394,49 @@
         "asap": "~2.0.6"
       }
     },
+    "node_modules/react-redux": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
+      "integrity": "sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/react-refresh": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
@@ -11409,6 +11496,22 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
       }
     },
     "node_modules/regenerate": {

--- a/react-native-coursework/section-6-meals-app/Meals/package.json
+++ b/react-native-coursework/section-6-meals-app/Meals/package.json
@@ -13,14 +13,16 @@
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
     "@react-navigation/stack": "^6.3.16",
+    "@reduxjs/toolkit": "^1.9.3",
     "expo": "~48.0.10",
     "expo-status-bar": "~1.4.4",
     "react": "18.2.0",
     "react-native": "0.71.6",
+    "react-native-gesture-handler": "~2.9.0",
+    "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",
-    "react-native-gesture-handler": "~2.9.0",
-    "react-native-reanimated": "~2.14.4"
+    "react-redux": "^8.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/react-native-coursework/section-6-meals-app/Meals/screens/CategoriesScreen.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/screens/CategoriesScreen.tsx
@@ -2,7 +2,6 @@ import { FlatList, ListRenderItemInfo } from "react-native";
 import { CATEGORIES } from "../data/meal-data";
 import Category from "../models/category";
 import CategoryGridTitle from "../components/CategoryGridTile";
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useNavigation } from "@react-navigation/native";
 
 function CategoriesScreen() {

--- a/react-native-coursework/section-6-meals-app/Meals/screens/FavoritesScreen.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/screens/FavoritesScreen.tsx
@@ -1,13 +1,15 @@
-import { useContext } from 'react';
-import { View, Text, StyleSheet } from 'react-native'
+import { View, Text, StyleSheet } from 'react-native';
+import { useSelector } from 'react-redux';
 
 import MealsList from '../components/MealsList/MealsList';
-import { FavoritesContext } from '../store/context/FavoritesContext';
 import { MEALS } from '../data/meal-data';
+import { store } from '../store/redux/store';
+
+type RootState = ReturnType<typeof store.getState>
 
 function FavoritesScreen() {
-  const favoriteMealsContext = useContext(FavoritesContext);
-  const favoriteMeals = MEALS.filter(meal => favoriteMealsContext.ids.includes(meal.id));
+  const favoriteMealIds = useSelector((state: RootState) => state.favoriteMeals.ids)
+  const favoriteMeals = MEALS.filter((meal) => favoriteMealIds.includes(meal.id));
   
   if (favoriteMeals.length === 0) {
     return (
@@ -18,7 +20,6 @@ function FavoritesScreen() {
   }
 
   return <MealsList items={favoriteMeals} />;
-    
 }
 
 export default FavoritesScreen;

--- a/react-native-coursework/section-6-meals-app/Meals/screens/FavoritesScreen.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/screens/FavoritesScreen.tsx
@@ -1,24 +1,38 @@
+import { useContext } from 'react';
 import { View, Text, StyleSheet } from 'react-native'
 
+import MealsList from '../components/MealsList/MealsList';
+import { FavoritesContext } from '../store/context/FavoritesContext';
+import { MEALS } from '../data/meal-data';
+
 function FavoritesScreen() {
-  return (
-          <View style={styles.screen}>
-            <Text style={styles.text}>Favorites</Text>
-            <Text style={styles.text}>This Favorites Screen will be implemented in next feature</Text>
-          </View>
-  )
+  const favoriteMealsContext = useContext(FavoritesContext);
+  const favoriteMeals = MEALS.filter(meal => favoriteMealsContext.ids.includes(meal.id));
+  
+  if (favoriteMeals.length === 0) {
+    return (
+      <View style={styles.rootContainer}>
+        <Text style={styles.text}>You have no favorite meals yet.</Text>
+      </View>
+    );
+  }
+
+  return <MealsList items={favoriteMeals} />;
+    
 }
 
 export default FavoritesScreen;
 
 const styles = StyleSheet.create({
-  screen: {
+  rootContainer: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center'
   },
   text: {
-    color: 'white',
-    margin: 10
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: 'white'
   }
+
 })

--- a/react-native-coursework/section-6-meals-app/Meals/screens/MealDetailScreen.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/screens/MealDetailScreen.tsx
@@ -112,6 +112,6 @@ const styles = StyleSheet.create({
     width: '80%'
   },
   headerIconContainer: {
-    paddingHorizontal: 25
+    paddingHorizontal: 20
   }
 })

--- a/react-native-coursework/section-6-meals-app/Meals/screens/MealDetailScreen.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/screens/MealDetailScreen.tsx
@@ -1,4 +1,5 @@
-import { useContext, useLayoutEffect } from "react";
+import { useLayoutEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
 import { View, Text, Image, StyleSheet, ScrollView } from "react-native";
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
@@ -6,8 +7,9 @@ import MealDetails from "../components/MealDetails";
 import Subtitle from "../components/MealDetail/Subtitle";
 import List from "../components/MealDetail/List";
 import IconButton from "../components/IconButton";
+import { store } from "../store/redux/store";
+import { addFavorite, removeFavorite } from "../store/redux/favorites";
 
-import { FavoritesContext } from "../store/context/FavoritesContext";
 import { MEALS } from "../data/meal-data";
 
 type RootStackParamList = {
@@ -17,6 +19,7 @@ type RootStackParamList = {
 };
 
 type Props = NativeStackScreenProps<RootStackParamList, 'MealDetail'>;
+type RootState = ReturnType<typeof store.getState>
 
 function findMeal(mealId: string) {
   function assert(value: unknown): asserts value {}
@@ -27,18 +30,19 @@ function findMeal(mealId: string) {
 }
 
 function MealDetailScreen( {route, navigation}: Props) {
-  const favoriteMealContext = useContext(FavoritesContext);
+  const favoriteMealIds = useSelector((state: RootState) => state.favoriteMeals.ids);
+  const dispatch = useDispatch();
 
   const mealId: string = route.params.mealId;
   const selectedMeal = findMeal(mealId);
 
-  const mealIsFavorite: boolean = favoriteMealContext.ids.includes(mealId);
+  const mealIsFavorite: boolean = favoriteMealIds.includes(mealId);
 
   function changeFavoriteStatusHandler() {
     if (mealIsFavorite) {
-      favoriteMealContext.removeFavorite(mealId);
+      dispatch(removeFavorite({ id: mealId }))
     } else {
-      favoriteMealContext.addFavorite(mealId);
+      dispatch(addFavorite({ id: mealId }));
     }
   }
 

--- a/react-native-coursework/section-6-meals-app/Meals/screens/MealDetailScreen.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/screens/MealDetailScreen.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect } from "react";
+import { useContext, useLayoutEffect } from "react";
 import { View, Text, Image, StyleSheet, ScrollView } from "react-native";
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
@@ -7,6 +7,7 @@ import Subtitle from "../components/MealDetail/Subtitle";
 import List from "../components/MealDetail/List";
 import IconButton from "../components/IconButton";
 
+import { FavoritesContext } from "../store/context/FavoritesContext";
 import { MEALS } from "../data/meal-data";
 
 type RootStackParamList = {
@@ -26,11 +27,19 @@ function findMeal(mealId: string) {
 }
 
 function MealDetailScreen( {route, navigation}: Props) {
+  const favoriteMealContext = useContext(FavoritesContext);
+
   const mealId: string = route.params.mealId;
   const selectedMeal = findMeal(mealId);
 
-  function headerButtonPressHandler() {
-    console.log('Pressed!');
+  const mealIsFavorite: boolean = favoriteMealContext.ids.includes(mealId);
+
+  function changeFavoriteStatusHandler() {
+    if (mealIsFavorite) {
+      favoriteMealContext.removeFavorite(mealId);
+    } else {
+      favoriteMealContext.addFavorite(mealId);
+    }
   }
 
   useLayoutEffect(() => {
@@ -39,15 +48,15 @@ function MealDetailScreen( {route, navigation}: Props) {
       headerRight: () => {
         return( 
                 <View style={styles.headerIconContainer}>
-                  <IconButton iconName="star"
-                              onPress={headerButtonPressHandler}
+                  <IconButton iconName={mealIsFavorite ? 'star' : 'star-outline'}
+                              onPress={changeFavoriteStatusHandler}
                               color={'white'}
                   />
                 </View>
               )
       }
     })
-  }, [navigation, headerButtonPressHandler]);
+  }, [navigation, changeFavoriteStatusHandler]);
 
   return(
     <ScrollView style={styles.rootContainer}>

--- a/react-native-coursework/section-6-meals-app/Meals/screens/MealsOverviewScreen.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/screens/MealsOverviewScreen.tsx
@@ -1,9 +1,9 @@
 import { useLayoutEffect } from "react";
-import { View, FlatList, StyleSheet, ListRenderItemInfo } from "react-native"
+import { View, FlatList } from "react-native"
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
 import { MEALS } from "../data/meal-data"
-import MealItem from "../components/MealItem";
+import MealsList from "../components/MealsList/MealsList";
 import Meal from "../models/meal";
 import { CATEGORIES } from "../data/meal-data";
 
@@ -33,33 +33,9 @@ function MealsOverviewScreen({ route, navigation }: Props) {
     
   }, [catId, navigation])
 
-  function renderMealItem(item: Meal) {
-    return <MealItem 
-            id={item.id}
-            title={item.title}
-            imageUrl={item.imageUrl}
-            duration={item.duration}
-            complexity={item.complexity}
-            affordability={item.affordability} 
-           />
-  }
+  
 
-  return (
-    <View style={styles.container}>
-      <FlatList 
-        data={displayedMeals}
-        keyExtractor={(item) => item.id}
-        renderItem={(itemData) => renderMealItem(itemData.item)}
-      />
-    </View>
-  )
+  return <MealsList items={displayedMeals}/>
 };
 
 export default MealsOverviewScreen;
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 16
-  }
-})

--- a/react-native-coursework/section-6-meals-app/Meals/screens/MealsOverviewScreen.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/screens/MealsOverviewScreen.tsx
@@ -1,5 +1,4 @@
 import { useLayoutEffect } from "react";
-import { View, FlatList } from "react-native"
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
 import { MEALS } from "../data/meal-data"

--- a/react-native-coursework/section-6-meals-app/Meals/store/context/FavoritesContext.tsx
+++ b/react-native-coursework/section-6-meals-app/Meals/store/context/FavoritesContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, useState } from "react";
+import { ReactNode } from "react";
+
+interface FavoritesContextProviderProps {
+  children: ReactNode
+}
+
+export const FavoritesContext = createContext({
+  ids: [] as string[],
+  addFavorite: (id: string) => {},
+  removeFavorite: (id: string) => {}
+});
+
+function FavoritesContextProvider({children}: FavoritesContextProviderProps) {
+  const [favoriteMealIds, setFavoriteMealIds] = useState<string[]>([]);
+
+  function addFavorite(id: string) {
+    setFavoriteMealIds((currentFavIds) => [...currentFavIds, id]);
+  }
+
+  function removeFavorite(id: string) {
+    setFavoriteMealIds((currentFavIds) => currentFavIds.filter(mealId => mealId !== id))
+  }
+
+  const value = {
+    ids: favoriteMealIds,
+    addFavorite: addFavorite,
+    removeFavorite: removeFavorite
+  }
+
+  return <FavoritesContext.Provider value={value}>{children}</FavoritesContext.Provider>
+}
+
+export default FavoritesContextProvider;

--- a/react-native-coursework/section-6-meals-app/Meals/store/redux/favorites.ts
+++ b/react-native-coursework/section-6-meals-app/Meals/store/redux/favorites.ts
@@ -1,0 +1,20 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const favoritesSlice = createSlice({
+  name: 'favorites',
+  initialState: {
+    ids: [] as string[]
+  },
+  reducers: {
+    addFavorite: (state, action) => {
+      state.ids.push(action.payload.id);
+    },
+    removeFavorite: (state, action) => {
+      state.ids.splice(state.ids.indexOf(action.payload.id), 1);
+    }
+  }
+});
+
+export const addFavorite = favoritesSlice.actions.addFavorite;
+export const removeFavorite = favoritesSlice.actions.removeFavorite;
+export default favoritesSlice.reducer;

--- a/react-native-coursework/section-6-meals-app/Meals/store/redux/store.ts
+++ b/react-native-coursework/section-6-meals-app/Meals/store/redux/store.ts
@@ -1,0 +1,8 @@
+import { configureStore } from "@reduxjs/toolkit";
+import favoritesReducer from './favorites';
+
+export const store = configureStore({
+  reducer: {
+    favoriteMeals: favoritesReducer
+  } 
+});


### PR DESCRIPTION
# User can favorite a meal and view favorited meals

User can favorite a meal by navigating to the MealDetailsScreen and clicking the star icon in the header of that meal. The user can then navigate to the FavoritesScreen to view the favorited meals.

Technical: Favorited meals state is managed through Redux. The star icon in the MealDetailsScreen header renders
as filled if this meal is a favoritedMeal. Otherwise, it renders as an outline. Clicking this icon adds/removes the meal in our favoriteMeals state. State is managed through reducers (addFavorite, removeFavorite).

![favorite](https://user-images.githubusercontent.com/49361894/231903434-bc2d6018-4c84-4855-9271-ec9f1c81597a.gif)
