### PR TITLE
User can manage expenses

### DIFF
--- a/react-native-projects/expense-tracker-app/ExpenseTracker/App.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/App.tsx
@@ -11,7 +11,12 @@ import IconButton from './components/UI/IconButton';
 
 import { GlobalStyles } from './constants/styles';
 
-const Stack = createNativeStackNavigator();
+type RootStackParamList = {
+  ManageExpense: {expenseId?: string}
+  ExpensesOverview: undefined
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
 const BottomTabs = createBottomTabNavigator();
 
 function ExpensesOverview() {
@@ -57,14 +62,24 @@ export default function App() {
     <>
       <StatusBar style='light' />
       <NavigationContainer>
-        <Stack.Navigator>
+        <Stack.Navigator
+          screenOptions={{
+            headerStyle: {
+              backgroundColor: GlobalStyles.colors.primary500
+            }
+          }}
+        >
           <Stack.Screen 
             name='ExpensesOverview' 
             component={ExpensesOverview}
             options={{headerShown: false}} 
           />
           <Stack.Screen name='ManageExpense' 
-                        component={ManageExpense}/>
+                        component={ManageExpense}
+                        options={{
+                          presentation: 'modal'
+                        }}
+          />
         </Stack.Navigator>
       </NavigationContainer>
     </>

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/App.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/App.tsx
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import { Ionicons } from '@expo/vector-icons'
 
+import ExpensesContextProvider from './store/ExpensesContext';
 import ManageExpense from './screens/ManageExpense';
 import RecentExpenses from './screens/RecentExpenses';
 import AllExpenses from './screens/AllExpenses';
@@ -61,28 +62,30 @@ export default function App() {
   return (
     <>
       <StatusBar style='light' />
-      <NavigationContainer>
-        <Stack.Navigator
-          screenOptions={{
-            headerStyle: {
-              backgroundColor: GlobalStyles.colors.primary500
-            }
-          }}
-        >
-          <Stack.Screen 
-            name='ExpensesOverview' 
-            component={ExpensesOverview}
-            options={{headerShown: false}} 
-          />
-          <Stack.Screen name='ManageExpense' 
-                        component={ManageExpense}
-                        options={{
-                          presentation: 'modal',
-                          headerTintColor: 'white'
-                        }}
-          />
-        </Stack.Navigator>
-      </NavigationContainer>
+      <ExpensesContextProvider>
+        <NavigationContainer>
+          <Stack.Navigator
+            screenOptions={{
+              headerStyle: {
+                backgroundColor: GlobalStyles.colors.primary500
+              }
+            }}
+          >
+            <Stack.Screen
+              name='ExpensesOverview'
+              component={ExpensesOverview}
+              options={{headerShown: false}}
+            />
+            <Stack.Screen name='ManageExpense'
+                          component={ManageExpense}
+                          options={{
+                            presentation: 'modal',
+                            headerTintColor: 'white'
+                          }}
+            />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </ExpensesContextProvider>
     </>
   );
 }

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/App.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/App.tsx
@@ -77,7 +77,8 @@ export default function App() {
           <Stack.Screen name='ManageExpense' 
                         component={ManageExpense}
                         options={{
-                          presentation: 'modal'
+                          presentation: 'modal',
+                          headerTintColor: 'white'
                         }}
           />
         </Stack.Navigator>

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ExpensesOutput/ExpenseItem.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ExpensesOutput/ExpenseItem.tsx
@@ -5,16 +5,19 @@ import { GlobalStyles } from "../../constants/styles";
 import { getFormattedDate } from "../../util/date";
 
 interface ExpenseItemProps {
+  id: string,
   description: string,
   amount: number,
   date: Date
 }
 
-function ExpenseItem({ description, amount, date }: ExpenseItemProps) {
+function ExpenseItem({ id, description, amount, date }: ExpenseItemProps) {
   const navigation = useNavigation();
 
   function expensePressHandler() {
-    navigation.navigate('ManageExpense' as never)
+    navigation.navigate('ManageExpense' as never, {
+      expenseId: id
+    } as never)
   }
 
   return (

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ExpensesOutput/ExpensesOutput.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ExpensesOutput/ExpensesOutput.tsx
@@ -1,4 +1,4 @@
-import { View, StyleSheet } from 'react-native'
+import { View, Text, StyleSheet } from 'react-native'
 
 import ExpensesList from "./ExpensesList";
 import ExpensesSummary from "./ExpensesSummary";
@@ -9,14 +9,22 @@ import { GlobalStyles } from '../../constants/styles';
 
 interface ExpeseOutputProps {
   expenses: Expense[],
-  expensesPeriod: string
+  expensesPeriod: string,
+  fallbackText: string
 }
 
-function ExpensesOutput( { expenses, expensesPeriod }: ExpeseOutputProps) {
+function ExpensesOutput( { expenses, expensesPeriod, fallbackText }: ExpeseOutputProps) {
+  let content = <Text style={styles.infoText}>{fallbackText}</Text>
+
+  if (expenses.length > 0) {
+    content = <ExpensesList expenses={expenses} />;
+
+  }
+
   return (
     <View style={styles.container}>
       <ExpensesSummary expenses={expenses} periodName={expensesPeriod}/>
-      <ExpensesList expenses={expenses} />
+      {content}
     </View>
 
   )
@@ -31,5 +39,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     paddingBottom: 0,
     backgroundColor: GlobalStyles.colors.primary700
+  },
+  infoText: {
+    color: 'white',
+    fontSize: 16,
+    textAlign: 'center',
+    marginTop: 32
   }
 })

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/UI/Button.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/UI/Button.tsx
@@ -1,0 +1,53 @@
+import { Pressable, Text, View, StyleSheet, GestureResponderEvent, ViewStyle } from 'react-native'
+import { ReactNode } from 'react';
+import { GlobalStyles } from '../../constants/styles';
+
+interface ButtonProps {
+  children: ReactNode,
+  onPress: (event: GestureResponderEvent) => void,
+  mode?: string,
+  style?: ViewStyle
+}
+
+function Button({children, onPress, mode, style}: ButtonProps) {
+  return (
+    <View style={style}>
+      <Pressable 
+        onPress={onPress}
+        style={({ pressed }) => pressed && styles.pressed}  
+      >
+        <View style={[styles.button, mode === 'flat' && styles.flat]}>
+          <Text style={[styles.buttonText, mode === 'flat' && styles.flatText]}>
+            {children}
+          </Text>
+        </View>
+      </Pressable>
+    </View>
+  )
+
+}
+
+export default Button;
+
+const styles = StyleSheet.create({
+  button: {
+    borderRadius: 4,
+    padding: 8,
+    backgroundColor: GlobalStyles.colors.primary500
+  },
+  flat: {
+    backgroundColor: 'transparent'
+  },
+  buttonText: {
+    color: 'white',
+    textAlign: 'center',
+  },
+  flatText: {
+    color: GlobalStyles.colors.primary200
+  },
+  pressed: {
+    opacity: 0.75,
+    backgroundColor: GlobalStyles.colors.primary100,
+    borderRadius: 4
+  }
+})

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/screens/AllExpenses.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/screens/AllExpenses.tsx
@@ -5,7 +5,11 @@ import ExpensesOutput from '../components/ExpensesOutput/ExpensesOutput';
 
 function AllExpenses() {
   const expensesContext = useContext(ExpensesContext)
-  return <ExpensesOutput expenses={expensesContext.expenses} expensesPeriod='Total'/>
+  return <ExpensesOutput 
+            expenses={expensesContext.expenses} 
+            expensesPeriod='Total'
+            fallbackText='No expenses found'
+          />
 }
 
 export default AllExpenses;

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/screens/AllExpenses.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/screens/AllExpenses.tsx
@@ -1,8 +1,11 @@
+import { useContext } from 'react';
+
+import { ExpensesContext } from '../store/ExpensesContext';
 import ExpensesOutput from '../components/ExpensesOutput/ExpensesOutput';
-import { DUMMY_EXPENSES } from '../data/dummy-expenses';
 
 function AllExpenses() {
-  return <ExpensesOutput expenses={DUMMY_EXPENSES} expensesPeriod='Total'/>
+  const expensesContext = useContext(ExpensesContext)
+  return <ExpensesOutput expenses={expensesContext.expenses} expensesPeriod='Total'/>
 }
 
 export default AllExpenses;

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
@@ -25,12 +25,16 @@ function ManageExpense({route, navigation}: Props) {
   }, [navigation, isEditing]);
 
   function deleteExpenseHandler() {
-
+    navigation.goBack();
   }
 
-  function cancelHandler() {}
+  function cancelHandler() {
+    navigation.goBack();
+  }
 
-  function confirmHandler() {}
+  function confirmHandler() {
+    navigation.goBack();
+  }
 
   return (
     <View style={styles.container}>

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
@@ -1,7 +1,8 @@
-import { useLayoutEffect } from 'react';
+import { useContext, useLayoutEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
+import { ExpensesContext } from '../store/ExpensesContext';
 import IconButton from '../components/UI/IconButton';
 import Button from '../components/UI/Button';
 
@@ -15,6 +16,8 @@ type RootStackParamList = {
 type Props = NativeStackScreenProps<RootStackParamList, 'ManageExpense'>;
 
 function ManageExpense({route, navigation}: Props) {
+  const expensesContext = useContext(ExpensesContext);
+
   const editedExpenseId = route.params?.expenseId;
   const isEditing = !!editedExpenseId;
 
@@ -25,6 +28,9 @@ function ManageExpense({route, navigation}: Props) {
   }, [navigation, isEditing]);
 
   function deleteExpenseHandler() {
+    if (editedExpenseId) {
+      expensesContext.deleteExpense(editedExpenseId);
+    }
     navigation.goBack();
   }
 
@@ -33,6 +39,24 @@ function ManageExpense({route, navigation}: Props) {
   }
 
   function confirmHandler() {
+    if (isEditing) {
+      expensesContext.updateExpense(
+        editedExpenseId,
+        {
+          description: 'Test!!!!!!',
+          amount: 29.99,
+          date: new Date('2023-04-20')
+        } as never
+      );
+    } else {
+      expensesContext.addExpense(
+        {
+          description: 'Test',
+          amount: 19.99,
+          date: new Date('2023-04-19')
+        } as never
+      );
+    }
     navigation.goBack();
   }
 

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
@@ -1,6 +1,11 @@
 import { useLayoutEffect } from 'react';
-import { Text } from 'react-native'
+import { View, StyleSheet } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+import IconButton from '../components/UI/IconButton';
+import Button from '../components/UI/Button';
+
+import { GlobalStyles } from '../constants/styles';
 
 type RootStackParamList = {
   ManageExpense: {expenseId?: string},
@@ -19,8 +24,70 @@ function ManageExpense({route, navigation}: Props) {
     })
   }, [navigation, isEditing]);
 
+  function deleteExpenseHandler() {
 
-  return <Text>ManageExpense Screen</Text>
+  }
+
+  function cancelHandler() {}
+
+  function confirmHandler() {}
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.buttonsContainer}>
+        <Button 
+          mode='flat' 
+          onPress={cancelHandler}
+          style={styles.button}
+        >
+          Cancel
+        </Button> 
+        <Button
+          onPress={confirmHandler}
+          style={styles.button}
+        >
+          {isEditing ? 'Update' : 'Add'}
+        </Button>
+      </View>
+      {isEditing && (
+        <View style={styles.deleteContainer}>
+          <IconButton
+            icon='trash'
+            color={GlobalStyles.colors.error500}
+            size={36}
+            onPress={deleteExpenseHandler}
+          />
+        </View>
+      )}
+
+    </View>
+  )
 }
 
 export default ManageExpense;
+
+const styles = StyleSheet.create({
+  container: { 
+    flex: 1,
+    padding: 24,
+    backgroundColor: GlobalStyles.colors.primary800
+    
+  },
+  buttonsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  button: {
+    minWidth: 120,
+    marginHorizontal: 8
+  },
+  deleteContainer: {
+    marginTop: 16,
+    paddingTop: 8,
+    borderTopWidth: 2,
+    borderTopColor: GlobalStyles.colors.primary200,
+    alignItems: 'center'
+
+  }
+})

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
@@ -1,6 +1,25 @@
+import { useLayoutEffect } from 'react';
 import { Text } from 'react-native'
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
-function ManageExpense() {
+type RootStackParamList = {
+  ManageExpense: {expenseId?: string},
+  ExpensesOverview: undefined
+};
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ManageExpense'>;
+
+function ManageExpense({route, navigation}: Props) {
+  const editedExpenseId = route.params?.expenseId;
+  const isEditing = !!editedExpenseId;
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: isEditing ? 'Edit Expense' : 'Add Expense'
+    })
+  }, [navigation, isEditing]);
+
+
   return <Text>ManageExpense Screen</Text>
 }
 

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/screens/RecentExpenses.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/screens/RecentExpenses.tsx
@@ -1,8 +1,19 @@
+import { useContext } from 'react';
+
+import { ExpensesContext } from '../store/ExpensesContext';
 import ExpensesOutput from '../components/ExpensesOutput/ExpensesOutput';
-import { DUMMY_EXPENSES } from '../data/dummy-expenses';
+import { getDateMinusDays } from '../util/date';
 
 function RecentExpenses() {
-  return <ExpensesOutput expenses={DUMMY_EXPENSES} expensesPeriod='Last 7 Days' />
+  const expensesContext = useContext(ExpensesContext)
+
+  const recentExpenses = expensesContext.expenses.filter((expenses) => {
+    const today = new Date();
+    const date7DaysAgo = getDateMinusDays(today, 7);
+
+    return expenses.date > date7DaysAgo;
+  })
+  return <ExpensesOutput expenses={recentExpenses} expensesPeriod='Last 7 Days' />
 }
 
 export default RecentExpenses;

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/screens/RecentExpenses.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/screens/RecentExpenses.tsx
@@ -7,13 +7,16 @@ import { getDateMinusDays } from '../util/date';
 function RecentExpenses() {
   const expensesContext = useContext(ExpensesContext)
 
-  const recentExpenses = expensesContext.expenses.filter((expenses) => {
+  const recentExpenses = expensesContext.expenses.filter((expense) => {
     const today = new Date();
     const date7DaysAgo = getDateMinusDays(today, 7);
 
-    return expenses.date > date7DaysAgo;
+    return (expense.date >= date7DaysAgo) && (expense.date <= today);
   })
-  return <ExpensesOutput expenses={recentExpenses} expensesPeriod='Last 7 Days' />
+  return <ExpensesOutput expenses={recentExpenses} 
+                         expensesPeriod='Last 7 Days' 
+                         fallbackText='No expenses in last 7 days'
+          />
 }
 
 export default RecentExpenses;

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/store/ExpensesContext.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/store/ExpensesContext.tsx
@@ -3,6 +3,7 @@ import { createContext, ReactNode, useReducer } from "react";
 import { Expense } from "../types/Expense";
 import { DUMMY_EXPENSES } from "../data/dummy-expenses";
 
+
 export const ExpensesContext = createContext({
   expenses: [] as Expense[],
   addExpense: ({description, amount, date}: Expense) => {},
@@ -26,22 +27,21 @@ interface ExpensesState {
 }
 
 
-function expensesReducer(state: ExpensesState, action: ExpensesAction) {
+function expensesReducer(state: Expense[], action: ExpensesAction) {
   switch (action.type) {
     case 'ADD':
       const id = new Date().toString() + Math.random().toString();
-      return [{ ...action.payload, id: id }, ...state.expenses]
+      return [{ ...action.payload, id: id }, ...state]
     case 'UPDATE':
-      const updatableExpenseIndex = state.expenses.findIndex(
+      const updatableExpenseIndex = state.findIndex(
         (expense: Expense) => expense.id === action.payload.id);
-      const updatableExpense = state.expenses[updatableExpenseIndex];
+      const updatableExpense = state[updatableExpenseIndex];
       const updatedItem = { ...updatableExpense, ...action.payload.data};
-      const updatedExpenses = [...state.expenses];
+      const updatedExpenses = [...state];
       updatedExpenses[updatableExpenseIndex] = updatedItem;
       return updatedExpenses;
     case 'DELETE':
-      return state.expenses.filter(
-        (expense: Expense) => expense.id !== action.payload);
+      return state.filter((expense) => expense.id !== action.payload);
     default:
       return state;
   }
@@ -54,7 +54,7 @@ interface ExpenseContextProviderProps {
 
 
 function ExpensesContextProvider({children}: ExpenseContextProviderProps) {
-  const [expensesState, dispatch] = useReducer(expensesReducer, DUMMY_EXPENSES as never);
+  const [expensesState, dispatch] = useReducer(expensesReducer, DUMMY_EXPENSES);
 
   function addExpense(expense: Expense) {
     dispatch({type: ExpenseActionKind.ADD, payload: expense });

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/store/ExpensesContext.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/store/ExpensesContext.tsx
@@ -1,0 +1,81 @@
+import { createContext, ReactNode, useReducer } from "react";
+
+import { Expense } from "../types/Expense";
+import { DUMMY_EXPENSES } from "../data/dummy-expenses";
+
+export const ExpensesContext = createContext({
+  expenses: [] as Expense[],
+  addExpense: ({description, amount, date}: Expense) => {},
+  deleteExpense: (id: string) => {},
+  updateExpense: (id: string, {description, amount, date}: Expense) => {}
+});
+
+enum ExpenseActionKind {
+  ADD = 'ADD',
+  UPDATE = 'UPDATE',
+  DELETE = 'DELETE'
+}
+
+interface ExpensesAction {
+  type: ExpenseActionKind;
+  payload?: any
+}
+
+interface ExpensesState {
+  expenses: Expense[]
+}
+
+
+function expensesReducer(state: ExpensesState, action: ExpensesAction) {
+  switch (action.type) {
+    case 'ADD':
+      const id = new Date().toString() + Math.random().toString();
+      return [{ ...action.payload, id: id }, ...state.expenses]
+    case 'UPDATE':
+      const updatableExpenseIndex = state.expenses.findIndex(
+        (expense: Expense) => expense.id === action.payload.id);
+      const updatableExpense = state.expenses[updatableExpenseIndex];
+      const updatedItem = { ...updatableExpense, ...action.payload.data};
+      const updatedExpenses = [...state.expenses];
+      updatedExpenses[updatableExpenseIndex] = updatedItem;
+      return updatedExpenses;
+    case 'DELETE':
+      return state.expenses.filter(
+        (expense: Expense) => expense.id !== action.payload);
+    default:
+      return state;
+  }
+  
+}
+
+interface ExpenseContextProviderProps {
+  children: ReactNode
+}
+
+
+function ExpensesContextProvider({children}: ExpenseContextProviderProps) {
+  const [expensesState, dispatch] = useReducer(expensesReducer, DUMMY_EXPENSES as never);
+
+  function addExpense(expense: Expense) {
+    dispatch({type: ExpenseActionKind.ADD, payload: expense });
+  }
+
+  function deleteExpense(id: string) {
+    dispatch({type: ExpenseActionKind.DELETE, payload: id})
+  }
+
+  function updateExpense(id: string, expense: Expense) {
+    dispatch({type: ExpenseActionKind.UPDATE, payload: {id: id, data: expense }})
+  }
+
+  const value = {
+    expenses: expensesState,
+    addExpense: addExpense,
+    deleteExpense: deleteExpense,
+    updateExpense: updateExpense
+  };
+
+  return <ExpensesContext.Provider value={value}>{children}</ExpensesContext.Provider>
+}
+
+export default ExpensesContextProvider

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/util/date.ts
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/util/date.ts
@@ -1,3 +1,7 @@
 export function getFormattedDate(date: Date) {
   return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
 }
+
+export function getDateMinusDays(date: Date, days: number) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() - days);
+}

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/util/date.ts
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/util/date.ts
@@ -1,5 +1,5 @@
 export function getFormattedDate(date: Date) {
-  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
+  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getUTCDate()}`
 }
 
 export function getDateMinusDays(date: Date, days: number) {


### PR DESCRIPTION
# User can manage expenses

## User can view recent expenses
User can view expenses from last 7 days
![recent-expenses](https://user-images.githubusercontent.com/49361894/233811487-2ccf04ea-3e44-45aa-a3c8-85e8990d17f2.gif)

## User can delete an expense
User can click on an expense to enter the ManageExpense (edit mode) screen. In this screen, the user can click the trash can icon to delete the expense.
![delete-expense](https://user-images.githubusercontent.com/49361894/233811522-5ef8bbb0-4723-4ce6-a4b2-4a3ebfd9b4a4.gif)

## User can add an expense
User can click the Plus icon in the header to enter the ManageExpense (add mode) screen. In the next feature, I will implement the user input for this screen. Currently, clicking add simply adds a mock expense titled "Test" with an expense amount of $19.99 and date of 4-19-2023. 
![add-expense](https://user-images.githubusercontent.com/49361894/233811586-0c1acf9f-d1e2-41c2-82e7-cb837b17b8df.gif)

## User can update an expense
User can click on an expense to enter the ManageExpense screen (edit mode). In the next feature, I will implement the user input for this screen. Currently, clicking update will update the clicked expense with mock data titled "Test!!!!!!" with an expense amount of $29.99 and date of 4-20-2023. 
![update-expense](https://user-images.githubusercontent.com/49361894/233811644-849e1e6c-cc96-4bec-be51-59b733c3c1e5.gif)

## App informs the user that there are no expenses in the last 7 days in the RecentExpenses screen. It also informs the user when there are no expenses in the AllExpenses screen. 
![no-expenses](https://user-images.githubusercontent.com/49361894/233811738-54790b9d-ca28-48ef-b97a-ca9c75e35038.gif)
