### PR TITLE
User Can Input Expense Data

### DIFF
--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
@@ -1,4 +1,4 @@
-import { View } from 'react-native'
+import { View, Text, StyleSheet } from 'react-native'
 import Input from './Input';
 
 function ExpenseForm() {
@@ -6,22 +6,27 @@ function ExpenseForm() {
 
   }
   return (
-    <View>
-      <Input 
-        label='Amount' 
-        textInputConfig={{
-          keyboardType: 'decimal-pad',
-          onChangeText: amountChangedHandler
-        }}
-      />
-      <Input 
-        label='Date'
-        textInputConfig={{
-          placeholder: 'YYYY-MM-DD',
-          maxLength: 10,
-          onChangeText: () => {}
-        }}
-      />
+    <View style={styles.form}>
+      <Text style={styles.title}>Your Expense</Text>
+      <View style={styles.inputsRow}>
+        <Input
+          label='Amount'
+          textInputConfig={{
+            keyboardType: 'decimal-pad',
+            onChangeText: amountChangedHandler
+          }}
+          style={styles.rowInput}
+        />
+        <Input
+          label='Date'
+          textInputConfig={{
+            placeholder: 'YYYY-MM-DD',
+            maxLength: 10,
+            onChangeText: () => {}
+          }}
+          style={styles.rowInput}
+        />
+      </View>
       <Input 
         label='Description'
         textInputConfig = {{
@@ -35,3 +40,23 @@ function ExpenseForm() {
 }
 
 export default ExpenseForm;
+
+const styles = StyleSheet.create({
+  form: {
+    marginTop: 40
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: 'white',
+    marginVertical: 24,
+    textAlign: 'center'
+  },
+  inputsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  rowInput:{
+    flex: 1
+  }
+})

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
@@ -4,6 +4,7 @@ import { GestureResponderEvent } from "react-native";
 
 import Input from './Input';
 import Button from '../UI/Button';
+import { Expense } from '../../types/Expense';
 
 type InputValues = {
   amount: string,
@@ -20,14 +21,15 @@ type ExpenseData = {
 interface ExpenseFormProps {
   onCancel: () => void,
   onSubmit: (expenseData: ExpenseData) => void,
-  submitButtonLabel: string
+  submitButtonLabel: string,
+  defaultValues: Expense | undefined
 }
 
-function ExpenseForm({onCancel, onSubmit, submitButtonLabel}: ExpenseFormProps) {
+function ExpenseForm({onCancel, onSubmit, submitButtonLabel, defaultValues}: ExpenseFormProps) {
   const [inputValues, setInputValues] = useState<InputValues>({
-    amount: '',
-    date: '',
-    description: ''
+    amount: defaultValues ? defaultValues.amount.toString() : '',
+    date: defaultValues ? defaultValues.date.toISOString().slice(0, 10) : '',
+    description: defaultValues ? defaultValues.description : ''
   });
 
   function inputChangeHandler(inputIdentifier: string, enteredValue: string) {

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
@@ -1,9 +1,52 @@
+import { useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native'
+import { GestureResponderEvent } from "react-native";
+
 import Input from './Input';
+import Button from '../UI/Button';
 
-function ExpenseForm() {
-  function amountChangedHandler() {
+type InputValues = {
+  amount: string,
+  date: string,
+  description: string
+}
 
+type ExpenseData = {
+  description: string,
+  amount: number,
+  date: Date
+}
+
+interface ExpenseFormProps {
+  onCancel: () => void,
+  onSubmit: (expenseData: ExpenseData) => void,
+  submitButtonLabel: string
+}
+
+function ExpenseForm({onCancel, onSubmit, submitButtonLabel}: ExpenseFormProps) {
+  const [inputValues, setInputValues] = useState<InputValues>({
+    amount: '',
+    date: '',
+    description: ''
+  });
+
+  function inputChangeHandler(inputIdentifier: string, enteredValue: string) {
+    setInputValues((currInputValues) => {
+      return {
+        ...currInputValues,
+        [inputIdentifier]: enteredValue
+      }
+    })
+  }
+
+  function submitHandler() {
+    const expenseData = {
+      amount: +inputValues.amount,
+      date: new Date(inputValues.date),
+      description: inputValues.description
+    };
+
+    onSubmit(expenseData);
   }
   return (
     <View style={styles.form}>
@@ -13,7 +56,8 @@ function ExpenseForm() {
           label='Amount'
           textInputConfig={{
             keyboardType: 'decimal-pad',
-            onChangeText: amountChangedHandler
+            onChangeText: (enteredValue) => inputChangeHandler('amount', enteredValue),
+            value: inputValues.amount
           }}
           style={styles.rowInput}
         />
@@ -22,7 +66,8 @@ function ExpenseForm() {
           textInputConfig={{
             placeholder: 'YYYY-MM-DD',
             maxLength: 10,
-            onChangeText: () => {}
+            onChangeText: (enteredValue) => inputChangeHandler('date', enteredValue),
+            value: inputValues.date
           }}
           style={styles.rowInput}
         />
@@ -31,8 +76,25 @@ function ExpenseForm() {
         label='Description'
         textInputConfig = {{
           multiline: true,
+          onChangeText: (enteredValue) => inputChangeHandler('description', enteredValue),
+          value: inputValues.description
         }}
       />
+            <View style={styles.buttonsContainer}>
+        <Button 
+          mode='flat' 
+          onPress={onCancel}
+          style={styles.button}
+        >
+          Cancel
+        </Button> 
+        <Button
+          onPress={submitHandler}
+          style={styles.button}
+        >
+          {submitButtonLabel}
+        </Button>
+      </View>
 
     </View>
   )
@@ -58,5 +120,14 @@ const styles = StyleSheet.create({
   },
   rowInput:{
     flex: 1
+  },
+  buttonsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  button: {
+    minWidth: 120,
+    marginHorizontal: 8
   }
 })

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native'
-import { GestureResponderEvent } from "react-native";
+import { View, Text, StyleSheet, Alert } from 'react-native'
 
 import Input from './Input';
 import Button from '../UI/Button';
@@ -47,6 +46,15 @@ function ExpenseForm({onCancel, onSubmit, submitButtonLabel, defaultValues}: Exp
       date: new Date(inputValues.date),
       description: inputValues.description
     };
+
+    const amountValid = !isNaN(expenseData.amount) && expenseData.amount > 0;
+    const dateIsValid = expenseData.date.toString() !== 'Invalid Date';
+    const descriptionIsValid = expenseData.description.trim().length > 0;
+
+    if (!amountValid || !dateIsValid || !descriptionIsValid) {
+      Alert.alert('Invalid input', 'Please check yout input values');
+      return;
+    }
 
     onSubmit(expenseData);
   }

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
@@ -1,0 +1,12 @@
+import { View } from 'react-native'
+
+function ExpenseForm() {
+  return (
+    <View>
+      
+    </View>
+  )
+
+}
+
+export default ExpenseForm;

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/ExpenseForm.tsx
@@ -1,9 +1,34 @@
 import { View } from 'react-native'
+import Input from './Input';
 
 function ExpenseForm() {
+  function amountChangedHandler() {
+
+  }
   return (
     <View>
-      
+      <Input 
+        label='Amount' 
+        textInputConfig={{
+          keyboardType: 'decimal-pad',
+          onChangeText: amountChangedHandler
+        }}
+      />
+      <Input 
+        label='Date'
+        textInputConfig={{
+          placeholder: 'YYYY-MM-DD',
+          maxLength: 10,
+          onChangeText: () => {}
+        }}
+      />
+      <Input 
+        label='Description'
+        textInputConfig = {{
+          multiline: true,
+        }}
+      />
+
     </View>
   )
 

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
@@ -1,5 +1,7 @@
-import { View, Text, TextInput, NativeSyntheticEvent, TextInputChangeEventData } from 'react-native'
-import { KeyboardType } from 'react-native'
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { KeyboardType } from 'react-native';
+import { GlobalStyles } from '../../constants/styles';
+import { TextStyle } from 'react-native';
 
 interface InputConfiguration {
   keyboardType?: KeyboardType,
@@ -15,12 +17,41 @@ interface InputProps {
 }
 
 function Input({label, textInputConfig}: InputProps) {
+  const inputStyles: TextStyle[] = [styles.input];
+
+  if (textInputConfig && textInputConfig.multiline) {
+    inputStyles.push(styles.inputMultiline);
+  }
+
   return (
-    <View>
-      <Text>{label}</Text>
-      <TextInput {...textInputConfig} />
+    <View style={styles.inputContainer}>
+      <Text style={styles.label}>{label}</Text>
+      <TextInput style={inputStyles} {...textInputConfig} />
     </View>
   )
 }
 
 export default Input;
+
+const styles = StyleSheet.create({
+  inputContainer: {
+    marginHorizontal: 4,
+    marginVertical: 10,
+  },
+  label: {
+    fontSize: 12,
+    color: GlobalStyles.colors.primary100,
+    marginBottom: 4
+  },
+  input: {
+    backgroundColor: GlobalStyles.colors.primary100,
+    color: GlobalStyles.colors.primary700,
+    padding: 6,
+    borderRadius: 6,
+    fontSize: 18,
+  },
+  inputMultiline: {
+    minHeight: 100,
+    textAlignVertical: 'top'
+  }
+})

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
@@ -8,7 +8,8 @@ interface InputConfiguration {
   maxLength?: number,
   placeholder?: string,
   multiline?: boolean,
-  onChangeText?: (text: string) => void
+  onChangeText?: (enteredValue: string) => void,
+  value?: string
 }
 
 interface InputProps {

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
@@ -9,25 +9,30 @@ interface InputConfiguration {
   placeholder?: string,
   multiline?: boolean,
   onChangeText?: (enteredValue: string) => void,
-  value?: string
+  value?: string,
 }
 
 interface InputProps {
   label: string,
   textInputConfig: InputConfiguration,
-  style?: ViewStyle
+  style?: ViewStyle,
+  invalid?: boolean
 }
 
-function Input({label, textInputConfig, style}: InputProps) {
+function Input({label, textInputConfig, invalid, style}: InputProps) {
   const inputStyles: TextStyle[] = [styles.input];
 
   if (textInputConfig && textInputConfig.multiline) {
     inputStyles.push(styles.inputMultiline);
   }
 
+  if (invalid) {
+    inputStyles.push(styles.invalidInput);
+  }
+
   return (
     <View style={[styles.inputContainer, style]}>
-      <Text style={styles.label}>{label}</Text>
+      <Text style={[styles.label, invalid && styles.invalidLabel]}>{label}</Text>
       <TextInput style={inputStyles} {...textInputConfig} />
     </View>
   )
@@ -55,5 +60,11 @@ const styles = StyleSheet.create({
   inputMultiline: {
     minHeight: 100,
     textAlignVertical: 'top'
+  },
+  invalidLabel: {
+    color: GlobalStyles.colors.error500
+  },
+  invalidInput: {
+    backgroundColor: GlobalStyles.colors.error50
   }
 })

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
@@ -1,0 +1,23 @@
+import { View, Text, TextInput } from 'react-native'
+import { KeyboardType } from 'react-native'
+
+interface InputConfiguration {
+  keyboardType: KeyboardType,
+  maxLength: number,
+}
+
+interface InputProps {
+  label: string,
+  textInputConfig: InputConfiguration
+}
+
+function Input({label, textInputConfig}: InputProps) {
+  return (
+    <View>
+      <Text>{label}</Text>
+      <TextInput {...textInputConfig} />
+    </View>
+  )
+}
+
+export default Input;

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { View, Text, TextInput, ViewStyle, StyleSheet } from 'react-native';
 import { KeyboardType } from 'react-native';
 import { GlobalStyles } from '../../constants/styles';
 import { TextStyle } from 'react-native';
@@ -13,10 +13,11 @@ interface InputConfiguration {
 
 interface InputProps {
   label: string,
-  textInputConfig: InputConfiguration
+  textInputConfig: InputConfiguration,
+  style?: ViewStyle
 }
 
-function Input({label, textInputConfig}: InputProps) {
+function Input({label, textInputConfig, style}: InputProps) {
   const inputStyles: TextStyle[] = [styles.input];
 
   if (textInputConfig && textInputConfig.multiline) {
@@ -24,7 +25,7 @@ function Input({label, textInputConfig}: InputProps) {
   }
 
   return (
-    <View style={styles.inputContainer}>
+    <View style={[styles.inputContainer, style]}>
       <Text style={styles.label}>{label}</Text>
       <TextInput style={inputStyles} {...textInputConfig} />
     </View>

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/components/ManageExpense/Input.tsx
@@ -1,9 +1,12 @@
-import { View, Text, TextInput } from 'react-native'
+import { View, Text, TextInput, NativeSyntheticEvent, TextInputChangeEventData } from 'react-native'
 import { KeyboardType } from 'react-native'
 
 interface InputConfiguration {
-  keyboardType: KeyboardType,
-  maxLength: number,
+  keyboardType?: KeyboardType,
+  maxLength?: number,
+  placeholder?: string,
+  multiline?: boolean,
+  onChangeText?: (text: string) => void
 }
 
 interface InputProps {

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
@@ -2,6 +2,7 @@ import { useContext, useLayoutEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
+import ExpenseForm from '../components/ManageExpense/ExpenseForm';
 import { ExpensesContext } from '../store/ExpensesContext';
 import IconButton from '../components/UI/IconButton';
 import Button from '../components/UI/Button';
@@ -62,6 +63,7 @@ function ManageExpense({route, navigation}: Props) {
 
   return (
     <View style={styles.container}>
+      <ExpenseForm />
       <View style={styles.buttonsContainer}>
         <Button 
           mode='flat' 

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
@@ -16,6 +16,12 @@ type RootStackParamList = {
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ManageExpense'>;
 
+type ExpenseData = {
+  description: string,
+  amount: number,
+  date: Date
+}
+
 function ManageExpense({route, navigation}: Props) {
   const expensesContext = useContext(ExpensesContext);
 
@@ -39,23 +45,14 @@ function ManageExpense({route, navigation}: Props) {
     navigation.goBack();
   }
 
-  function confirmHandler() {
+  function confirmHandler(expenseData: ExpenseData) {
     if (isEditing) {
       expensesContext.updateExpense(
-        editedExpenseId,
-        {
-          description: 'Test!!!!!!',
-          amount: 29.99,
-          date: new Date('2023-04-20')
-        } as never
+        editedExpenseId, expenseData as never
       );
     } else {
       expensesContext.addExpense(
-        {
-          description: 'Test',
-          amount: 19.99,
-          date: new Date('2023-04-19')
-        } as never
+        expenseData as never
       );
     }
     navigation.goBack();
@@ -63,22 +60,12 @@ function ManageExpense({route, navigation}: Props) {
 
   return (
     <View style={styles.container}>
-      <ExpenseForm />
-      <View style={styles.buttonsContainer}>
-        <Button 
-          mode='flat' 
-          onPress={cancelHandler}
-          style={styles.button}
-        >
-          Cancel
-        </Button> 
-        <Button
-          onPress={confirmHandler}
-          style={styles.button}
-        >
-          {isEditing ? 'Update' : 'Add'}
-        </Button>
-      </View>
+      <ExpenseForm 
+        onCancel={cancelHandler}
+        onSubmit={confirmHandler}
+        submitButtonLabel= {isEditing ? 'Update' : 'Add'}
+      />
+
       {isEditing && (
         <View style={styles.deleteContainer}>
           <IconButton
@@ -102,15 +89,6 @@ const styles = StyleSheet.create({
     padding: 24,
     backgroundColor: GlobalStyles.colors.primary800
     
-  },
-  buttonsContainer: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center'
-  },
-  button: {
-    minWidth: 120,
-    marginHorizontal: 8
   },
   deleteContainer: {
     marginTop: 16,

--- a/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
+++ b/react-native-projects/expense-tracker-app/ExpenseTracker/screens/ManageExpense.tsx
@@ -8,6 +8,7 @@ import IconButton from '../components/UI/IconButton';
 import Button from '../components/UI/Button';
 
 import { GlobalStyles } from '../constants/styles';
+import { Expense } from '../types/Expense';
 
 type RootStackParamList = {
   ManageExpense: {expenseId?: string},
@@ -27,6 +28,10 @@ function ManageExpense({route, navigation}: Props) {
 
   const editedExpenseId = route.params?.expenseId;
   const isEditing = !!editedExpenseId;
+
+  const selectedExpense = expensesContext.expenses.find((expense: Expense) => {
+    return expense.id === editedExpenseId;
+  })
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -64,6 +69,7 @@ function ManageExpense({route, navigation}: Props) {
         onCancel={cancelHandler}
         onSubmit={confirmHandler}
         submitButtonLabel= {isEditing ? 'Update' : 'Add'}
+        defaultValues = {selectedExpense}
       />
 
       {isEditing && (


### PR DESCRIPTION
# User can input expense data when adding/updating an expense.

## User can add an expense

When a user clicks the plus icon in the header, they are presented with a Form to enter expense data. The data fields include the description, amount, and date of the expense. 

![add-expense](https://user-images.githubusercontent.com/49361894/235071023-bfcdd0c0-bcbe-4590-83a5-7da310a1587a.gif)

## User can update an expense

When a user clicks on an expense, they are able to update the expense's description, amount, and/or date.

![edit-expense](https://user-images.githubusercontent.com/49361894/235071440-4de8f7d4-e609-4c38-9838-4d493b973607.gif)

## ExpenseForm implemented with input validation as well as validation feedback to the user. The invalid input is highlighted to the user and an error text is displayed. 

![form-validation-add](https://user-images.githubusercontent.com/49361894/235071717-a5a66c80-b9c8-43ab-a148-42849fc4cf34.gif)

![form-validation-edit](https://user-images.githubusercontent.com/49361894/235071752-296c40f1-83af-4843-aa69-45226babcf0a.gif)

![form-validation-empty](https://user-images.githubusercontent.com/49361894/235071780-8d11eaaa-4321-462e-b452-78bb737b7aff.gif)


